### PR TITLE
Restructure images and charts defaults to best practices

### DIFF
--- a/class/cert-exporter.yml
+++ b/class/cert-exporter.yml
@@ -2,10 +2,11 @@ parameters:
   kapitan:
     dependencies:
       - type: helm
-        source: https://charts.enix.io
+        source: ${cert_exporter:charts:x509-certificate-exporter:source}
         chart_name: x509-certificate-exporter
-        version: ${cert_exporter:chart}
-        output_path: dependencies/cert-exporter/helmcharts/cert-exporter/${cert_exporter:chart}/
+        version: ${cert_exporter:charts:x509-certificate-exporter:version}
+        output_path: dependencies/cert-exporter/helmcharts/cert-exporter/${cert_exporter:charts:x509-certificate-exporter:version}/
+
     compile:
       - input_paths:
           - cert-exporter/component/app.jsonnet
@@ -24,7 +25,7 @@ parameters:
         input_type: jsonnet
         output_path: cert-exporter/
       - input_paths:
-          - dependencies/cert-exporter/helmcharts/cert-exporter/${cert_exporter:chart}/
+          - dependencies/cert-exporter/helmcharts/cert-exporter/${cert_exporter:charts:x509-certificate-exporter:version}/
         input_type: helm
         output_path: cert-exporter/10_helmchart
         helm_values: ${cert_exporter:helm_values}

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,13 +3,17 @@ parameters:
     =_metadata: {}
     namespace: syn-cert-exporter
 
-    chart: 1.20.0
+    charts:
+      x509-certificate-exporter:
+        source: https://charts.enix.io
+        version: 1.20.0
 
-    image:
-      registry: quay.io
-      repository: enix/x509-certificate-exporter
-      tag: 2.12.1
-      pullPolicy: IfNotPresent
+    images:
+      x509-certificate-exporter:
+        registry: quay.io
+        repository: enix/x509-certificate-exporter
+        tag: 2.12.1
+        pullPolicy: IfNotPresent
 
     ignore_alerts: []
 
@@ -26,7 +30,7 @@ parameters:
     daemonsets: {}
 
     helm_values:
-      image: ${cert_exporter:image}
+      image: ${cert_exporter:images:x509-certificate-exporter}
       podAnnotations:
         prometheus.io/port: "9793"
         prometheus.io/scrape: "true"

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -2,6 +2,21 @@
 
 The parent key for all of the following parameters is `cert_exporter`.
 
+== `images`
+
+[horizontal]
+type:: dictionary
+
+Dictionary containing the container images used by this component.
+
+
+== `charts`
+
+[horizontal]
+type:: dictionary
+
+Dictionary containing the helm charts used by this component.
+
 == `ignore_alerts`
 
 [horizontal]


### PR DESCRIPTION
By sticking to the best practices when defining image and chart defaults renovate will be able to parse the versions and generate PRs.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
