### PR TITLE
Add ways to patch included rules

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -15,7 +15,18 @@ parameters:
         tag: 2.12.1
         pullPolicy: IfNotPresent
 
-    ignore_alerts: []
+    alerts:
+      # Cert-exporter alerts to ignore
+      # The component supports removal of entries from this array by
+      # giving the entry prefixed with `~` (same syntax as for the
+      # applications array).
+      ignoreNames: []
+      # Alert rule patches.
+      # Provide partial objects for alert rules that need to be tuned compared to
+      # upstream. The keys in this object correspond to the `alert` field of the
+      # rule for which the patch is intended.
+      patchRules: {}
+
 
     # secrets exporter configs
     include_namespaces: []

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -27,7 +27,6 @@ parameters:
       # rule for which the patch is intended.
       patchRules: {}
 
-
     # secrets exporter configs
     include_namespaces: []
     exclude_namespaces: []

--- a/component/alertrules.jsonnet
+++ b/component/alertrules.jsonnet
@@ -13,8 +13,17 @@ assert
 
 // Upstream alerts to ignore
 local ignore_alerts = std.set(
+  local legacyIgnores =
+    if std.objectHas(params, 'ignore_alerts') then
+      std.trace(
+        'Parameter `cert_exporter.ignore_alerts` is deprecated, please '
+        + 'migrate your config to use parameter `alerts.ignoreNames` instead',
+        params.ignore_alerts
+      )
+    else
+      [];
   // Add set of alerts that should be ignored from `params.alerts`
-  com.renderArray(params.alerts.ignoreNames)
+  com.renderArray(legacyIgnores + params.alerts.ignoreNames)
 );
 
 /* FROM HERE: should be provided as library function by

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -17,14 +17,41 @@ type:: dictionary
 
 Dictionary containing the helm charts used by this component.
 
-== `ignore_alerts`
+== `alerts`
+
+[horizontal]
+type:: dictionary
+
+Configuration parameters related to influencing the resulting alert rules.
+
+=== `ignoreNames`
 
 [horizontal]
 type:: list
-default:: []
+default:: `[]`
 
 This parameter can be used to disable alerts provided by cert-exporter.
 The component supports removing entries in this parameter by providing the entry prefixed with `~`.
+
+=== `patchRules`
+
+[horizontal]
+type:: dict
+default:: {}
+
+This parameter allows users to patch upstream alert.
+The keys in the parameter correspond to the field `alertname` of the alert to patch.
+The component expects valid partial Prometheus alert rule objects as values.
+
+IMPORTANT: The provided values aren't validated, they're applied to the corresponding upstream alert as-is.
+
+.Example
+[source,yaml]
+----
+patchRules:
+  SYN_CertificateExpiration:
+    expr: '((x509_cert_not_after{secret_namespace=~"(syn|vshn).*"} - time()) / 86400) < 14'
+----
 
 == `include_namespaces`
 

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -3,6 +3,13 @@ applications:
 
 parameters:
   cert_exporter:
+    alerts:
+      ignoreNames:
+        - SYN_CertificateRenewal
+      patchRules:
+        SYN_CertificateExpiration:
+          expr: '((x509_cert_not_after{secret_namespace=~"(syn|vshn).*"} - time()) / 86400) < 14'
+
     watch_dirs:
       - /etc/kubernetes/ssl
     daemonsets:

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -3,6 +3,8 @@ applications:
 
 parameters:
   cert_exporter:
+    ignore_alerts:
+      - SYN_CertificateError
     alerts:
       ignoreNames:
         - SYN_CertificateRenewal

--- a/tests/golden/defaults/cert-exporter/cert-exporter/20_rules.yaml
+++ b/tests/golden/defaults/cert-exporter/cert-exporter/20_rules.yaml
@@ -49,24 +49,6 @@ spec:
             severity: critical
             syn: 'true'
             syn_component: cert-exporter
-        - alert: SYN_CertificateRenewal
-          annotations:
-            description: 'Certificate for {{ $labels.subject_CN }} in Kubernetes secret
-
-              {{ $labels.secret_name }} in namespace {{ $labels.secret_namespace }}
-
-              should be renewed.
-
-              '
-            message: Certificate should be renewed
-            runbook_url: https://hub.syn.tools/cert-exporter/runbooks/CertificateRenewal.html
-            severity_level: warning
-          expr: ((x509_cert_not_after - time()) / 86400) < 28
-          for: 15m
-          labels:
-            severity: warning
-            syn: 'true'
-            syn_component: cert-exporter
         - alert: SYN_CertificateExpiration
           annotations:
             description: 'Certificate for {{ $labels.subject_CN }} in Kubernetes secret
@@ -79,7 +61,8 @@ spec:
             message: Certificate is about to expire
             runbook_url: https://hub.syn.tools/cert-exporter/runbooks/CertificateExpiration.html
             severity_level: critical
-          expr: ((x509_cert_not_after - time()) / 86400) < 14
+          expr: ((x509_cert_not_after{secret_namespace=~"(syn|vshn).*"} - time())
+            / 86400) < 14
           for: 15m
           labels:
             severity: critical

--- a/tests/golden/defaults/cert-exporter/cert-exporter/20_rules.yaml
+++ b/tests/golden/defaults/cert-exporter/cert-exporter/20_rules.yaml
@@ -30,25 +30,6 @@ spec:
             severity: warning
             syn: 'true'
             syn_component: cert-exporter
-        - alert: SYN_CertificateError
-          annotations:
-            description: 'Certificate at location {{ $labels.filepath }} in Kubernetes
-              secret
-
-              {{ $labels.secret_name }} in namespace {{ $labels.secret_namespace }}
-
-              couldn''t be decoded.
-
-              '
-            message: Certificate cannot be decoded
-            runbook_url: https://hub.syn.tools/cert-exporter/runbooks/CertificateError.html
-            severity_level: critical
-          expr: x509_cert_error > 0
-          for: 5m
-          labels:
-            severity: critical
-            syn: 'true'
-            syn_component: cert-exporter
         - alert: SYN_CertificateExpiration
           annotations:
             description: 'Certificate for {{ $labels.subject_CN }} in Kubernetes secret


### PR DESCRIPTION
This now works the same as for the component-rook-ceph and should slightly improve ductape solutions [like this (internal)](https://git.vshn.net/syn/commodore-defaults/-/blob/master/apps/appuio-cloud-zone/params.yml#L154)

The change is fully backward compatible.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
