### PR TITLE
Increase default CPU limits for cert-exporter

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -49,10 +49,16 @@ parameters:
         excludeNamespaces: ${cert_exporter:exclude_namespaces}
         includeLabels: ${cert_exporter:include_labels}
         excludeLabels: ${cert_exporter:exclude_labels}
+        resources:
+          limits:
+            cpu: 500m
       hostPathsExporter:
         watchDirectories: ${cert_exporter:watch_dirs}
         watchFiles: ${cert_exporter:watch_files}
         watchKubeconfFiles: ${cert_exporter:watch_kubeconf}
         daemonSets: ${cert_exporter:daemonsets}
+        resources:
+          limits:
+            cpu: 250m
       prometheusRules:
         create: false

--- a/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/daemonset.yaml
+++ b/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/daemonset.yaml
@@ -36,7 +36,7 @@ spec:
               name: metrics
           resources:
             limits:
-              cpu: 100m
+              cpu: 250m
               memory: 40Mi
             requests:
               cpu: 10m
@@ -105,7 +105,7 @@ spec:
               name: metrics
           resources:
             limits:
-              cpu: 100m
+              cpu: 250m
               memory: 40Mi
             requests:
               cpu: 10m

--- a/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/deployment.yaml
+++ b/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               name: metrics
           resources:
             limits:
-              cpu: 200m
+              cpu: 500m
               memory: 100Mi
             requests:
               cpu: 10m


### PR DESCRIPTION
We've observed heavy CPU throttling with the default limits on multiple clusters. For the secrets exporter, the CPU throttling had spikes of up to 0.2 seconds / scheduled second, which led to frequent TargetDown alerts in Prometheus with the default scrape timeout of 10s.

After updating the CPU limit for the secrets exporter to 500m manually on one affected cluster, throttling consistently stays below 0.02 seconds / scheduled second, and we haven't had any TargetDown alerts since adjusting the limit.

This commit updates the default CPU limits for the secrets and hostpaths exporters to 500m and 250m respectively, increasing both limits by a factor 2.5. We keep the memory requests and limits, and the CPU requests, since those are generally reasonable looking at the resource consumption of the pods.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
