### PR TITLE
Fix default CPU limit for cert-exporter v2.13.0

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -51,7 +51,7 @@ parameters:
         excludeLabels: ${cert_exporter:exclude_labels}
         resources:
           limits:
-            cpu: 500m
+            cpu: 1000m
       hostPathsExporter:
         watchDirectories: ${cert_exporter:watch_dirs}
         watchFiles: ${cert_exporter:watch_files}

--- a/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/deployment.yaml
+++ b/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               name: metrics
           resources:
             limits:
-              cpu: 500m
+              cpu: 1000m
               memory: 100Mi
             requests:
               cpu: 10m


### PR DESCRIPTION
After determining a good CPU limit to avoid excessive throttling for cert-exporter v2.12.1 (cf. #24), we also merged #8 to update the cert-exporter container image to v2.13.0. However, it turns out that the CPU requirements for v2.13.0 are completely different to v2.12.1.

After some more experimentation we've determined that 1000m seems to be a default CPU limit for v2.13.0 where we avoid excessive throttling even on clusters with larger amounts of certificates.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
