### PR TITLE
Fix metrics scraping running into timeout

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -63,3 +63,6 @@ parameters:
             cpu: 250m
       prometheusRules:
         create: false
+      prometheusServiceMonitor:
+        scrapeInterval: 90s
+        scrapeTimeout: 70s

--- a/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/servicemonitor.yaml
+++ b/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/servicemonitor.yaml
@@ -11,9 +11,9 @@ metadata:
   namespace: syn-cert-exporter
 spec:
   endpoints:
-    - interval: 60s
+    - interval: 90s
       port: metrics
-      scrapeTimeout: 30s
+      scrapeTimeout: 70s
   selector:
     matchLabels:
       app.kubernetes.io/instance: cert-exporter


### PR DESCRIPTION
When havin many certificates on a cluster, prometheus can run into the configured timout. Increasing scrape interval and timout settings of service monitor.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
