### PR TITLE
Fix CrashLoopBackOff on larger clusters

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -55,6 +55,12 @@ parameters:
         resources:
           limits:
             cpu: 1000m
+        readinessProbe:
+          initialDelaySeconds: 25
+          periodSeconds: 10
+        livenessProbe:
+          initialDelaySeconds: 25
+          periodSeconds: 10
       hostPathsExporter:
         priorityClassName: system-node-critical
         watchDirectories: ${cert_exporter:watch_dirs}

--- a/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/deployment.yaml
+++ b/tests/golden/defaults/cert-exporter/cert-exporter/10_helmchart/x509-certificate-exporter/templates/deployment.yaml
@@ -36,8 +36,8 @@ spec:
             httpGet:
               path: /healthz
               port: metrics
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 25
+            periodSeconds: 10
           name: x509-certificate-exporter
           ports:
             - containerPort: 9793
@@ -46,8 +46,8 @@ spec:
             httpGet:
               path: /healthz
               port: metrics
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 25
+            periodSeconds: 10
           resources:
             limits:
               cpu: 1000m


### PR DESCRIPTION
Clusters with many namespaces and secrets/TLS experience significant delays when starting the HTTP server.
https://github.com/enix/x509-certificate-exporter/issues/483




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
